### PR TITLE
Add dallas bike ride section to home page and left-align bike plan

### DIFF
--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -309,6 +309,39 @@ export type Homepage = {
       _key: string;
     }>;
   };
+  dallasBikeRide?: {
+    heading?: string;
+    photo?: {
+      asset?: {
+        _ref: string;
+        _type: "reference";
+        _weak?: boolean;
+        [internalGroqTypeReferenceTo]?: "sanity.imageAsset";
+      };
+      hotspot?: SanityImageHotspot;
+      crop?: SanityImageCrop;
+      altText?: string;
+      _type: "image";
+    };
+    content?: Array<{
+      children?: Array<{
+        marks?: Array<string>;
+        text?: string;
+        _type: "span";
+        _key: string;
+      }>;
+      style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+      listItem?: "bullet" | "number";
+      markDefs?: Array<{
+        href?: string;
+        _type: "link";
+        _key: string;
+      }>;
+      level?: number;
+      _type: "block";
+      _key: string;
+    }>;
+  };
 };
 
 export type EmailCityCouncil = {
@@ -692,7 +725,7 @@ export type PostsResult = {
   }>;
 } | null;
 // Variable: homePage
-// Query: *[_type == "homepage"]{      _id,      _createdAt,      title,      "slug": slug.current,      content,      "homePageHeroImage": {        "asset": homePageHeroImage.asset->url,        "altText": homePageHeroImage.altText      },      "whoWeAre": {        "heading": whoWeAre.heading,        "photo": {          "asset": whoWeAre.photo.asset->url,          "altText": whoWeAre.photo.altText        },        "content" : whoWeAre.content      },      "whatWeDo": {        "heading": whatWeDo.heading,        "whatWeDoPics": whatWeDo.whatWeDoPics[] {          "image": image.asset->url,          "altText": altText,          "caption": caption        }      },      "bikePlan": {        "heading": bikePlan.heading,        "content": bikePlan.content      }    }[0]
+// Query: *[_type == "homepage"]{      _id,      _createdAt,      title,      "slug": slug.current,      content,      "homePageHeroImage": {        "asset": homePageHeroImage.asset->url,        "altText": homePageHeroImage.altText      },      "whoWeAre": {        "heading": whoWeAre.heading,        "photo": {          "asset": whoWeAre.photo.asset->url,          "altText": whoWeAre.photo.altText        },        "content" : whoWeAre.content      },      "whatWeDo": {        "heading": whatWeDo.heading,        "whatWeDoPics": whatWeDo.whatWeDoPics[] {          "image": image.asset->url,          "altText": altText,          "caption": caption        }      },      "bikePlan": {        "heading": bikePlan.heading,        "content": bikePlan.content      },      "dallasBikeRide": {        "heading": dallasBikeRide.heading,        "photo": {          "asset": dallasBikeRide.photo.asset->url,          "altText": dallasBikeRide.photo.altText        },        "content" : dallasBikeRide.content      },    }[0]
 export type HomePageResult = {
   _id: string;
   _createdAt: string;
@@ -738,6 +771,31 @@ export type HomePageResult = {
   };
   bikePlan: {
     heading: string | null;
+    content: Array<{
+      children?: Array<{
+        marks?: Array<string>;
+        text?: string;
+        _type: "span";
+        _key: string;
+      }>;
+      style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+      listItem?: "bullet" | "number";
+      markDefs?: Array<{
+        href?: string;
+        _type: "link";
+        _key: string;
+      }>;
+      level?: number;
+      _type: "block";
+      _key: string;
+    }> | null;
+  };
+  dallasBikeRide: {
+    heading: string | null;
+    photo: {
+      asset: string | null;
+      altText: string | null;
+    };
     content: Array<{
       children?: Array<{
         marks?: Array<string>;
@@ -1059,7 +1117,7 @@ import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
     "\n      *[_type == \"post\" && slug.current == $slug][0]{\n        ...,\n        author->{\n          name\n        }\n      }": PostsResult;
-    "\n    *[_type == \"homepage\"]{\n      _id,\n      _createdAt,\n      title,\n      \"slug\": slug.current,\n      content,\n      \"homePageHeroImage\": {\n        \"asset\": homePageHeroImage.asset->url,\n        \"altText\": homePageHeroImage.altText\n      },\n      \"whoWeAre\": {\n        \"heading\": whoWeAre.heading,\n        \"photo\": {\n          \"asset\": whoWeAre.photo.asset->url,\n          \"altText\": whoWeAre.photo.altText\n        },\n        \"content\" : whoWeAre.content\n      },\n      \"whatWeDo\": {\n        \"heading\": whatWeDo.heading,\n        \"whatWeDoPics\": whatWeDo.whatWeDoPics[] {\n          \"image\": image.asset->url,\n          \"altText\": altText,\n          \"caption\": caption\n        }\n      },\n      \"bikePlan\": {\n        \"heading\": bikePlan.heading,\n        \"content\": bikePlan.content\n      }\n    }[0]": HomePageResult;
+    "\n    *[_type == \"homepage\"]{\n      _id,\n      _createdAt,\n      title,\n      \"slug\": slug.current,\n      content,\n      \"homePageHeroImage\": {\n        \"asset\": homePageHeroImage.asset->url,\n        \"altText\": homePageHeroImage.altText\n      },\n      \"whoWeAre\": {\n        \"heading\": whoWeAre.heading,\n        \"photo\": {\n          \"asset\": whoWeAre.photo.asset->url,\n          \"altText\": whoWeAre.photo.altText\n        },\n        \"content\" : whoWeAre.content\n      },\n      \"whatWeDo\": {\n        \"heading\": whatWeDo.heading,\n        \"whatWeDoPics\": whatWeDo.whatWeDoPics[] {\n          \"image\": image.asset->url,\n          \"altText\": altText,\n          \"caption\": caption\n        }\n      },\n      \"bikePlan\": {\n        \"heading\": bikePlan.heading,\n        \"content\": bikePlan.content\n      },\n      \"dallasBikeRide\": {\n        \"heading\": dallasBikeRide.heading,\n        \"photo\": {\n          \"asset\": dallasBikeRide.photo.asset->url,\n          \"altText\": dallasBikeRide.photo.altText\n        },\n        \"content\" : dallasBikeRide.content\n      },\n    }[0]": HomePageResult;
     "\n    *[_type == \"policyPage\"]{\n      _id,\n      _createdAt,\n      title,\n      \"introBlock\": {\n        \"heading\": introBlock.heading,\n        \"content\": introBlock.content\n      },\n      \"policyRows\": policyRows[] {\n        \"policy\": policy,\n        \"summary\": summary,\n        \"moreInfo\": moreInfo,\n      },\n      \"legislativeDemands\": {\n        \"heading\": legislativeDemands.heading,\n        \"content\": legislativeDemands.content\n      },\n    }[0]": PolicyPageResult;
     "\n    *[_type == \"layout\"][0]{\n      _id,\n      _createdAt,\n      \"logo\": {\n        \"asset\": logo.asset->url,\n        \"altText\": logo.altText\n      },\n      \"landingPageLink\": landingPageLink\n    }": LayoutResult;
     "\n    *[_type == \"aboutUs\"]{\n      _id,\n      _createdAt,\n      title,\n      \"mission\": {\n        \"heading\": mission.heading,\n        \"content\": mission.content\n      },\n      \"vision\": {\n        \"heading\": vision.heading,\n        \"content\": vision.content\n      },\n      \"team\": {\n        \"heading\": team.heading,\n        \"members\": team.members[]{\n          \"name\": name\n        }\n      },\n      \"howToHelp\": {\n        \"heading\": howToHelp.heading,\n        \"content\": howToHelp.content\n      },\n    }[0]": AboutUsPageResult;

--- a/schema.json
+++ b/schema.json
@@ -2300,6 +2300,270 @@
           }
         },
         "optional": true
+      },
+      "dallasBikeRide": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "heading": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "photo": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "object",
+                "attributes": {
+                  "asset": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "object",
+                      "attributes": {
+                        "_ref": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "_type": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "string",
+                            "value": "reference"
+                          }
+                        },
+                        "_weak": {
+                          "type": "objectAttribute",
+                          "value": {
+                            "type": "boolean"
+                          },
+                          "optional": true
+                        }
+                      },
+                      "dereferencesTo": "sanity.imageAsset"
+                    },
+                    "optional": true
+                  },
+                  "hotspot": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageHotspot"
+                    },
+                    "optional": true
+                  },
+                  "crop": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "inline",
+                      "name": "sanity.imageCrop"
+                    },
+                    "optional": true
+                  },
+                  "altText": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string"
+                    },
+                    "optional": true
+                  },
+                  "_type": {
+                    "type": "objectAttribute",
+                    "value": {
+                      "type": "string",
+                      "value": "image"
+                    }
+                  }
+                }
+              },
+              "optional": true
+            },
+            "content": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "array",
+                "of": {
+                  "type": "object",
+                  "attributes": {
+                    "children": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "array",
+                        "of": {
+                          "type": "object",
+                          "attributes": {
+                            "marks": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "array",
+                                "of": {
+                                  "type": "string"
+                                }
+                              },
+                              "optional": true
+                            },
+                            "text": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              },
+                              "optional": true
+                            },
+                            "_type": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string",
+                                "value": "span"
+                              }
+                            }
+                          },
+                          "rest": {
+                            "type": "object",
+                            "attributes": {
+                              "_key": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "optional": true
+                    },
+                    "style": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "union",
+                        "of": [
+                          {
+                            "type": "string",
+                            "value": "normal"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h1"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h2"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h3"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h4"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h5"
+                          },
+                          {
+                            "type": "string",
+                            "value": "h6"
+                          },
+                          {
+                            "type": "string",
+                            "value": "blockquote"
+                          }
+                        ]
+                      },
+                      "optional": true
+                    },
+                    "listItem": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "union",
+                        "of": [
+                          {
+                            "type": "string",
+                            "value": "bullet"
+                          },
+                          {
+                            "type": "string",
+                            "value": "number"
+                          }
+                        ]
+                      },
+                      "optional": true
+                    },
+                    "markDefs": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "array",
+                        "of": {
+                          "type": "object",
+                          "attributes": {
+                            "href": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string"
+                              },
+                              "optional": true
+                            },
+                            "_type": {
+                              "type": "objectAttribute",
+                              "value": {
+                                "type": "string",
+                                "value": "link"
+                              }
+                            }
+                          },
+                          "rest": {
+                            "type": "object",
+                            "attributes": {
+                              "_key": {
+                                "type": "objectAttribute",
+                                "value": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "optional": true
+                    },
+                    "level": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "number"
+                      },
+                      "optional": true
+                    },
+                    "_type": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string",
+                        "value": "block"
+                      }
+                    }
+                  },
+                  "rest": {
+                    "type": "object",
+                    "attributes": {
+                      "_key": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "optional": true
+            }
+          }
+        },
+        "optional": true
       }
     }
   },

--- a/schema/singletons/homePageSchema.ts
+++ b/schema/singletons/homePageSchema.ts
@@ -108,5 +108,38 @@ export const homePageSchema = defineType({
         },
       ],
     },
+    {
+      name: "dallasBikeRide",
+      title: "Dallas Bike Ride 2025",
+      type: "object",
+      fields: [
+        {
+          name: "heading",
+          title: "Heading",
+          type: "string",
+        },
+        {
+          name: "photo",
+          title: "Dallas Bike Ride Photo",
+          type: "image",
+          fields: [
+            {
+              name: "altText",
+              type: "string",
+              title: "Alternative text",
+            },
+          ],
+          options: {
+            hotspot: true,
+          },
+        },
+        {
+          name: "content",
+          title: "Content",
+          type: "array",
+          of: [{ type: "block" }],
+        },
+      ],
+    },
   ],
 });

--- a/src/globals.css
+++ b/src/globals.css
@@ -263,11 +263,6 @@ div.normal-copy p:not(:last-child):not(:-moz-last-node) {
   text-align: center;
 }
 
-/* Specific element styling */
-#bike-plan {
-  text-align: center;
-}
-
 .main-post-image {
   margin-bottom: 1em;
   margin-top: 1em;

--- a/src/globals.css
+++ b/src/globals.css
@@ -263,6 +263,7 @@ div.normal-copy p:not(:last-child):not(:-moz-last-node) {
   text-align: center;
 }
 
+/* Specific element styling */
 .main-post-image {
   margin-bottom: 1em;
   margin-top: 1em;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,17 +56,62 @@ const homePage = await getHomePage();
       }
     </div>
   </section>
-
-  <section id="bike-plan">
-    <h2>{homePage?.bikePlan.heading}</h2>
-    <div class="two-cols">
-      {
-        homePage?.bikePlan.content && (
-          <div class="normal-copy">
-            <PortableText value={homePage.bikePlan.content} />
-          </div>
-        )
-      }
-    </div>
+  
+  <section id="sections">
+    <section id="bike-plan">
+      <h2>{homePage?.bikePlan.heading}</h2>
+      <div class="two-cols">
+        {
+          homePage?.bikePlan.content && (
+            <div class="normal-copy">
+              <PortableText value={homePage.bikePlan.content} />
+            </div>
+          )
+        }
+      </div>
+    </section>
+  
+    <section id="bike-ride">
+      <h2>{homePage?.dallasBikeRide.heading}</h2>
+      <div>
+        {
+          homePage?.dallasBikeRide.photo.asset && (
+            <img
+              id="bike-ride-img"
+              src={urlFor(homePage.dallasBikeRide.photo.asset).url()}
+              alt={homePage.dallasBikeRide.photo.altText || "Dallas Bike Ride image"}
+            />
+          )
+        }
+        {
+          homePage?.dallasBikeRide.content && (
+            <div class="normal-copy">
+              <PortableText value={homePage.dallasBikeRide.content} />
+            </div>
+          )
+        }
+      </div>
+    </section>
   </section>
+
+  
+
+  <style>
+    #sections {
+      display:flex;
+      flex-wrap: wrap;
+      gap: 2em;
+    }
+    #bike-plan {
+      flex: 1;
+    }
+    #bike-ride {
+      flex: 1;
+    }
+    #bike-ride-img {
+      min-width: 300px;
+      margin-bottom: 5px;
+    }
+  </style>
+
 </Layout>

--- a/src/utils/groqQueries.ts
+++ b/src/utils/groqQueries.ts
@@ -66,7 +66,15 @@ export async function getHomePage(): Promise<HomePageResult> {
       "bikePlan": {
         "heading": bikePlan.heading,
         "content": bikePlan.content
-      }
+      },
+      "dallasBikeRide": {
+        "heading": dallasBikeRide.heading,
+        "photo": {
+          "asset": dallasBikeRide.photo.asset->url,
+          "altText": dallasBikeRide.photo.altText
+        },
+        "content" : dallasBikeRide.content
+      },
     }[0]`;
 
   const results = await sanityClient.fetch(homePage);


### PR DESCRIPTION
https://github.com/DallasBicycleCoalition/DBC-Site/issues/35

1920x1080
![image](https://github.com/user-attachments/assets/c0774769-eeef-42c6-ac9b-a1eac7e8d6ec)

1280x720
![image](https://github.com/user-attachments/assets/602dd1bc-e938-409c-a2a4-4bde59cd734b)

375x812 (my phone's viewport)
![image](https://github.com/user-attachments/assets/ffb9c343-859b-446b-8911-20e511a45136)

- The images are all kind of small, especially the square ones, but I think this should be good enough
- I decided to group these due to a large amount of white space and inconsistent left vs center alignment
- I removed the extra line breaks from the bike plan section in sanity (locally)
- If you prefer them to be vertically organized instead I can change it
- Do I put the prod CMS changes after it finishes deploying?