### PR TITLE
Improve contributor-facing repo setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+PUBLIC_SANITY_PROJECT_ID="wfdg37xd"
+PUBLIC_SANITY_DATASET="production"
+
+# Optional: use these if the Studio/project differs by environment.
+# PUBLIC_SANITY_STUDIO_PROJECT_ID=""
+# PUBLIC_SANITY_STUDIO_DATASET=""
+
+# Optional: required only for authenticated Sanity API operations.
+# SANITY_API_TOKEN=""

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ pnpm-debug.log*
 
 # Local settings
 .vscode/
+.codex

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WebsiteFrontEnd
+# DBC Site
 
-This is the repository for all code related to the DBC website
+This repository contains the Astro frontend and Sanity CMS admin for the Dallas Bicycle Coalition website.
 
 Template used as reference: https://github.com/sanity-io/sanity-template-astro-clean
 
@@ -32,9 +32,11 @@ Template used as reference: https://github.com/sanity-io/sanity-template-astro-c
 
 ## Development (in progress)
 
-For any local development you'll want to pull the repo down and setup a .env file with
+For any local development you'll want to pull the repo down and set up a `.env` file. You can copy `.env.example` and fill in the values:
 
 ```
+cp .env.example .env
+
 PUBLIC_SANITY_PROJECT_ID="wfdg37xd"
 PUBLIC_SANITY_DATASET="production"
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "dbc-site",
   "type": "module",
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
## Summary
- rename the package from `app` to `dbc-site`
- improve README naming and local env setup instructions
- add `.env.example`
- remove the accidental `.codex` file and ignore it going forward

## Verification
- `npm run build`
